### PR TITLE
Configuration of Jetty maven plug-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Running the example
 -------------------
 mvn jetty:run
 
+Jetty scans the classpath every three seconds for updates and redeploys if it finds changes on classes.
+
+mvn jetty:stop
+
+Stops Jetty.
+
 
 Importing in Eclipse
 --------------------

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>7.0.0</vaadin.version>
+		<vaadin.version>7.7.24</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 	</properties>
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -133,11 +133,17 @@
 			<plugin>
 				<groupId>org.mortbay.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
+				<configuration>
+					<stopPort>9966</stopPort>
+					<stopKey>foo</stopKey>
+					<scanIntervalSeconds>3</scanIntervalSeconds>
+				</configuration>
 			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+				<!--This plugin's configuration is used to store Eclipse m2e settings 
+					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
 					<artifactId>lifecycle-mapping</artifactId>


### PR DESCRIPTION
I added some configurations to the Jetty maven plugin. 

Jetty scans the classpath every three seconds and redeploys if there are updates on classes. With this option you can play with the adddressbook example and see the results directly in the browser without restarting Jetty.

I also added configurations for stopping the Jetty server with mvn jetty:stop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/addressbook/2)
<!-- Reviewable:end -->
